### PR TITLE
Relativize output links

### DIFF
--- a/void-updates.sh
+++ b/void-updates.sh
@@ -140,8 +140,8 @@ create_heading() {
 }
 
 make_current() {
-  ln -sf $dest.txt $out/$name.txt
-  ln -sfn $dest $out/$name
+  ln -sf $dest.txt $name.txt
+  ln -sfn $dest $name
 }
 
 while getopts "p:r:s:o:" opt; do


### PR DESCRIPTION
Also fixes that the 'local' keyword is being used and the script is being called by /bin/sh.