### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE=ghcr.io/void-linux/void-linux:20210312rc01-thin-x86_64-musl
+FROM ${BASE}
+RUN xbps-install -yMU git bash curl util-linux findutils
+COPY void-updates.sh /usr/local/bin/void-updates
+COPY entrypoint.sh /entrypoint
+
+# Needed to allow the update checker to run as root.
+ENV XBPS_ALLOW_CHROOT_BREAKOUT=1
+ENV PARALLELISM=20
+
+ENTRYPOINT ["/entrypoint"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ -d /void-packages-origin/.git ] ; then
+    printf "local origin is possible, bootstrapping from that...\n"
+    git clone /void-packages-origin /void-packages
+fi
+
+/usr/local/bin/void-updates \
+    -p "$PARALLELISM" \
+    -r https://github.com/void-linux/void-packages.git \
+    -s /void-packages \
+    -o /void-updates

--- a/void-updates.sh
+++ b/void-updates.sh
@@ -7,14 +7,12 @@ init_src() {
     mkdir -p $src
     git clone -q $repo $src
   fi
-
-  if ! [ -d $src/hostdir/binpkgs ]; then
-    (cd $src && ./xbps-src binary-bootstrap)
-  fi
 }
 
 update_src() {
+  printf "updating clone\n"
   GIT_WORK_TREE=$src GIT_DIR=$src/.git git pull -q
+  printf "update complete\n"
 }
 
 is_meta() {
@@ -106,6 +104,7 @@ add_homepage() {
 }
 
 parallel_check() {
+  printf "beginning checks\n"
   xargs -P20 -L1 /bin/sh -c "
     (cd $src && ./xbps-src update-check \$0) |
     sed -e \"s|\$0-||g\" -e \"s|^|\$0 |\" >> \$1


### PR DESCRIPTION
This includes a dockerfile and entrypoint script.  The idea is that clones are optimized by having a void-packages checkout available that is updated weekly, so at most the initial update is 7 days of changes.  This does not include the CI/CD pipeline to actually build the image, only the instructions to do so.